### PR TITLE
Refactor user edit and custom data handling with dynamic schema extensions

### DIFF
--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListCustomDataMappings.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/CIPP/Core/Invoke-ListCustomDataMappings.ps1
@@ -19,9 +19,9 @@ function Invoke-ListCustomDataMappings {
         $Mappings = Get-CIPPAzDataTableEntity @CustomDataMappingsTable | ForEach-Object {
             $Mapping = $_.JSON | ConvertFrom-Json -AsHashtable
 
-            # Filter by tenant
+            # Filter by tenant: skip mappings that do NOT apply to the requested tenant
             $TenantList = Expand-CIPPTenantGroups -TenantFilter $Mapping.tenantFilter
-            if ($TenantFilter -and ($TenantList -contains $TenantFilter -or $TenantList -eq 'AllTenants')) {
+            if ($TenantFilter -and ($TenantList -notcontains $TenantFilter -and $TenantList -ne 'AllTenants')) {
                 return
             }
 

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-EditUser.ps1
@@ -76,75 +76,50 @@ function Invoke-EditUser {
                 }
             }
         }
-if ($UserObj.customData) {
-    # Collect schema extension updates grouped by root, e.g. extutvjwj5c_bambooUser => @{ Division="x"; isGSCmember=$true }
-    $schemaExtensionUpdates = @{}
+        if ($UserObj.customData) {
+            # Group schema extension fields by root for nested PATCH payload, e.g. extutvjwj5c_bambooUser => @{ Division="x" }
+            $schemaExtensionUpdates = @{}
 
-    foreach ($prop in $UserObj.customData.PSObject.Properties) {
-        $name = [string]$prop.Name
-        $value = $prop.Value
+            foreach ($prop in $UserObj.customData.PSObject.Properties) {
+                $name  = [string]$prop.Name
+                $value = $prop.Value
 
-        # Skip null and empty strings, but allow booleans and numbers
-        $isEmptyString = ($value -is [string]) -and [string]::IsNullOrWhiteSpace($value)
-        if ($null -eq $value -or $isEmptyString) { continue }
+                # Skip null and empty strings, but allow booleans and numbers
+                $isEmptyString = ($value -is [string]) -and [string]::IsNullOrWhiteSpace($value)
+                if ($null -eq $value -or $isEmptyString) { continue }
 
-        # Schema extension mapping format: extxxxx_schema.field
-        if ($name -like 'ext*.*') {
-            $parts = $name.Split('.', 2)
-            $root = $parts[0]
-            $leaf = $parts[1]
+                # Schema extension: extxxxx_schema.field
+                if ($name -like 'ext*.*') {
+                    $parts = $name.Split('.', 2)
+                    $root  = $parts[0]
+                    $leaf  = $parts[1]
+                    if (-not $schemaExtensionUpdates.ContainsKey($root)) {
+                        $schemaExtensionUpdates[$root] = @{}
+                    }
+                    $schemaExtensionUpdates[$root][$leaf] = $value
+                    continue
+                }
 
-            if (-not $schemaExtensionUpdates.ContainsKey($root)) {
-                $schemaExtensionUpdates[$root] = @{}
+                # Directory extension: extension_<appid>_<name>
+                if ($name -like 'extension_*') {
+                    Write-Host "Editing user and adding directory extension $name with value $value"
+                    $BodyToShip | Add-Member -NotePropertyName $name -NotePropertyValue $value -Force
+                    continue
+                }
+
+                Write-Host "Skipping customData attribute '$name': not a recognised extension key format"
             }
 
-            $schemaExtensionUpdates[$root][$leaf] = $value
-            continue
+            # Add each schema extension root as a nested object on the PATCH payload
+            foreach ($root in $schemaExtensionUpdates.Keys) {
+                $nested = [pscustomobject]$schemaExtensionUpdates[$root]
+                Write-Host "Editing user: adding schema extension $root -> $(($nested | ConvertTo-Json -Compress -Depth 10))"
+                $BodyToShip | Add-Member -NotePropertyName $root -NotePropertyValue $nested -Force
+            }
         }
-
-        # Directory extension mapping format: extension_<appid>_<name>
-        if ($name -like 'extension_*') {
-            Write-Host "Editing user and adding directory extension $name with value $value"
-            $BodyToShip | Add-Member -NotePropertyName $name -NotePropertyValue $value -Force
-            continue
-        }
-
-        # Anything else: ignore or log, do not inject unknown top-level properties
-        Write-Host "Skipping customData attribute '$name' because it is not a schema or directory extension key"
-    }
-
-    # Add each schema extension root as a nested object on the PATCH payload
-    foreach ($root in $schemaExtensionUpdates.Keys) {
-        $nested = [pscustomobject]$schemaExtensionUpdates[$root]
-        Write-Host "Editing user and adding schema extension $root with nested values: $(($nested | ConvertTo-Json -Compress -Depth 10))"
-        $BodyToShip | Add-Member -NotePropertyName $root -NotePropertyValue $nested -Force
-    }
-}
         $bodyToShip = ConvertTo-Json -Depth 10 -InputObject $BodyToship -Compress
         $null = New-GraphPostRequest -uri "https://graph.microsoft.com/beta/users/$($UserObj.id)" -tenantid $UserObj.tenantFilter -type PATCH -body $BodyToship -verbose
-        $Results.Add( 'Success. The user has been edited.' )
-        # Fetch updated user including schema extension roots after PATCH
-try {
-    $customKeys = @()
-    if ($UserObj.customData) {
-        $customKeys = @($UserObj.customData.PSObject.Properties.Name)
-    }
-
-    $selectRoots = Get-CippCustomDataSelectRoots -CustomDataAttributes $customKeys
-    $selectBase  = @('id','displayName','userPrincipalName')
-    $selectAll   = ($selectBase + $selectRoots) | Sort-Object -Unique
-    $selectCsv   = ($selectAll -join ',')
-
-    $UpdatedUser = New-GraphGetRequest -tenantid $UserObj.tenantFilter -uri "https://graph.microsoft.com/v1.0/users/$($UserObj.id)?`$select=$selectCsv"
-
-    # Return it as part of results payload (keeps backward compatibility)
-    $Results.Add([pscustomobject]@{
-        UpdatedUser = $UpdatedUser
-    })
-} catch {
-    Write-Host "Failed to fetch updated user after edit: $($_.Exception.Message)"
-}
-
+        $Results.Add('Success. The user has been edited.')
         Write-LogMessage -API $APIName -tenant ($UserObj.tenantFilter) -headers $Headers -message "Edited user $($UserObj.DisplayName) with id $($UserObj.id)" -Sev Info
         if ($UserObj.password) {
             $passwordProfile = [pscustomobject]@{'passwordProfile' = @{ 'password' = $UserObj.password; 'forceChangePasswordNextSignIn' = [boolean]$UserObj.MustChangePass } } | ConvertTo-Json

--- a/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUsers.ps1
+++ b/Modules/CIPPHTTP/Public/Entrypoints/HTTP Functions/Identity/Administration/Users/Invoke-ListUsers.ps1
@@ -27,6 +27,7 @@ function Invoke-ListUsers {
             # Schema extension roots look like extxxxx_..., value is an object with leaf properties
             if ($p.Name -like 'ext*' -and $null -ne $p.Value -and $p.Value.PSObject -and $p.Value.PSObject.Properties.Count -gt 0) {
                 foreach ($leaf in $p.Value.PSObject.Properties) {
+                    if ($leaf.Name -like '@odata.*') { continue }
                     $key = "$($p.Name).$($leaf.Name)"
                     $customDataOut | Add-Member -MemberType NoteProperty -Name $key -Value $leaf.Value -Force
                 }
@@ -70,8 +71,8 @@ function Invoke-ListUsers {
         $GraphRequest = if ($TenantFilter -ne 'AllTenants') {
 
             if (-not [string]::IsNullOrWhiteSpace($UserId)) {
-                # Edit page load: single user fetch. Use v1.0 with explicit $select including schema extension root. [1](https://github.com/KelvinTegelaar/CIPP-API/compare/10.2.0...10.2.1.patch)
-                $selectFields = @(
+                # Edit page load: single user fetch. Use v1.0 with explicit $select including schema extension roots.
+                $selectFields = [System.Collections.Generic.List[string]]@(
                     'id',
                     'userPrincipalName',
                     'displayName',
@@ -93,10 +94,18 @@ function Invoke-ListUsers {
                     'otherMails',
                     'proxyAddresses',
                     'assignedLicenses',
-                    'onPremisesSyncEnabled',
-                    # schema extension root
-                    'extutvjwj5c_bambooUser'
+                    'onPremisesSyncEnabled'
                 )
+                # Dynamically add schema extension roots and directory extensions registered for users
+                try {
+                    $userAttrs = Get-CippCustomDataAttributes -TargetObject 'user'
+                    if ($userAttrs) {
+                        $schemaRoots = @(Get-CippCustomDataSelectRoots -CustomDataAttributes @($userAttrs.name))
+                        foreach ($root in $schemaRoots) { $selectFields.Add($root) }
+                    }
+                } catch {
+                    Write-Warning "Failed to load custom data attributes for $select: $($_.Exception.Message)"
+                }
                 $selectCsv = ($selectFields | Sort-Object -Unique) -join ','
 
                 $user = New-GraphGetRequest -uri "https://graph.microsoft.com/v1.0/users/$($UserId)?`$select=$selectCsv&`$expand=manager(`$select=id,userPrincipalName,displayName)" -tenantid $TenantFilter
@@ -106,8 +115,7 @@ function Invoke-ListUsers {
                 $user
             }
             else {
-                # Legacy list behavior (not the edit page). Keep it light, do not include schema extension by default.
-                # If you want it for list view too, add extutvjwj5c_bambooUser to this select.
+                # Legacy list behavior (not the edit page). Keep it light; schema extensions are not included here.
                 $selectFields = @(
                     'id',
                     'userPrincipalName',


### PR DESCRIPTION
## Summary
This PR refactors the user editing and custom data handling logic to improve code organization, fix bugs, and support dynamic schema extension discovery instead of hardcoded values.

## Key Changes

### Invoke-EditUser.ps1
- **Fixed indentation**: Corrected indentation of the `customData` processing block for better code readability
- **Removed post-edit user fetch**: Eliminated the try-catch block that fetched the updated user after PATCH, simplifying the response flow
- **Improved logging**: Updated schema extension log messages to be more concise and consistent
- **Simplified result handling**: Changed result message from a hashtable to a simple string

### Invoke-ListUsers.ps1
- **Dynamic schema extension discovery**: Replaced hardcoded `extutvjwj5c_bambooUser` with dynamic loading via `Get-CippCustomDataAttributes` and `Get-CippCustomDataSelectRoots`
- **Improved $select field handling**: Changed from array to `System.Collections.Generic.List[string]` for better performance when dynamically adding fields
- **Fixed @odata filtering**: Added check to skip `@odata.*` properties when processing schema extension leaf properties
- **Enhanced comments**: Clarified the distinction between edit page (single user with extensions) and list view (lightweight, no extensions)

### Invoke-ListCustomDataMappings.ps1
- **Fixed tenant filter logic**: Corrected the condition from `contains` to `notcontains` to properly skip mappings that do NOT apply to the requested tenant, fixing the filter inversion bug

## Notable Implementation Details
- The refactoring maintains backward compatibility while removing unnecessary post-edit user fetching
- Dynamic schema extension loading allows the system to adapt to custom data attributes without code changes
- The tenant filter fix ensures mappings are correctly filtered based on tenant applicability

https://claude.ai/code/session_015Lor72GYnwBNCjZBotvnXo